### PR TITLE
fix: specify generic type

### DIFF
--- a/advanced_alchemy/types/datetime.py
+++ b/advanced_alchemy/types/datetime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime
 from sqlalchemy.types import TypeDecorator
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Dialect
 
 
-class DateTimeUTC(TypeDecorator[Optional[datetime.datetime]]):
+class DateTimeUTC(TypeDecorator[datetime.datetime]):
     """Timezone Aware DateTime.
 
     Ensure UTC is stored in the database and that TZ aware dates are returned for all dialects.

--- a/advanced_alchemy/types/datetime.py
+++ b/advanced_alchemy/types/datetime.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Dialect
 
 
-class DateTimeUTC(TypeDecorator):
+class DateTimeUTC(TypeDecorator[datetime.datetime | None]):
     """Timezone Aware DateTime.
 
     Ensure UTC is stored in the database and that TZ aware dates are returned for all dialects.

--- a/advanced_alchemy/types/datetime.py
+++ b/advanced_alchemy/types/datetime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import DateTime
 from sqlalchemy.types import TypeDecorator
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Dialect
 
 
-class DateTimeUTC(TypeDecorator[datetime.datetime | None]):
+class DateTimeUTC(TypeDecorator[Optional[datetime.datetime]]):
     """Timezone Aware DateTime.
 
     Ensure UTC is stored in the database and that TZ aware dates are returned for all dialects.


### PR DESCRIPTION
This PR introduces a modification to the `DateTimeUTC` class, changing the generic type to allow the column to be either `datetime.datetime` or `None`. This adjustment would be useful for static analyzers to perform their tasks without raising errors.